### PR TITLE
ci: lintの追加とhookの改良

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt
-        args: --all
+        args: --all -- --check
 
   build:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types:
+      - opened
+      - synchronize
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all
+
   build:
 
     runs-on: ubuntu-latest

--- a/chapter2/src/2_4_4/client.rs
+++ b/chapter2/src/2_4_4/client.rs
@@ -1,5 +1,5 @@
+use std::io::{copy, stdout, Write};
 use std::net::TcpStream;
-use std::io::{Write, stdout, copy};
 
 fn main() -> std::io::Result<()> {
     let mut stream = TcpStream::connect("ascii.jp:80")?;


### PR DESCRIPTION
- 元の定義だと `master` に向けた PR でしかCIが走らないはずなので、どこに向けたPRでも走るように。
- `lint` job を追加し、 `cargo fmt` をかける。