### PR TITLE
ci: rustfmt を明示的にインストールしないと cargo fmt が失敗する場合がある

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Install rust-toolchain with rustfmt
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        components: rustfmt
+
     - name: cargo fmt
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
@yuk1ty 
https://github.com/yuk1ty/learning-systems-programming-in-rust/pull/20/checks?check_run_id=2467792506 で失敗を確認しました。

これを master にマージしたあと、 https://github.com/yuk1ty/learning-systems-programming-in-rust/pull/20 はmasterにrebaseする必要がありそうです 🙇 