### PR TITLE
2.8 Q1: fmt::Write に対して write!() で書式文字列を書き込み、それを一時ファイルに出力し、確認用に読込んで標準出力に表示するプログラム

### DIFF
--- a/chapter2/Cargo.toml
+++ b/chapter2/Cargo.toml
@@ -19,3 +19,7 @@ path = "src/2_4_2/main.rs"
 [[bin]]
 name = "client_2_4_4"
 path = "src/2_4_4/client.rs"
+
+[[bin]]
+name = "2_8_1"
+path = "src/2_8_1/main.rs"

--- a/chapter2/src/2_8_1/main.rs
+++ b/chapter2/src/2_8_1/main.rs
@@ -1,0 +1,60 @@
+//! Write format string to a file using `write!` macro (Go version uses `Fprintf`).
+
+use std::{
+    env::temp_dir,
+    fmt,
+    fs::File,
+    io::{self, Read, Write},
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn mktemp() -> PathBuf {
+    let mut tempdir = temp_dir();
+
+    let tempfile = {
+        let now = SystemTime::now();
+        let unixtime = now
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock maybe corrupt");
+        format!("{}-{:09}", unixtime.as_secs(), unixtime.subsec_nanos())
+    };
+
+    tempdir.push(tempfile);
+    tempdir
+}
+
+fn write_fmt<W: fmt::Write>(w: &mut W) {
+    write!(
+        w,
+        "{{}}(\"10\"): {}, {{}}(10): {}, {{:.1}}(10.0): {:.1}\n",
+        "10", 10, 10.0
+    )
+    .expect("wrong format string")
+}
+
+fn main() -> io::Result<()> {
+    let tmp_path = mktemp();
+    {
+        let mut contents = String::new();
+        write_fmt(&mut contents);
+        let mut f = File::create(&tmp_path)?;
+        f.write(contents.as_bytes())?;
+    }
+    let written_contents = {
+        let mut f = File::open(&tmp_path)?;
+        let mut contents = String::new();
+        let _ = f.read_to_string(&mut contents)?;
+        contents
+    };
+
+    println!(
+        "Written to '{}' :",
+        tmp_path
+            .to_str()
+            .expect("should ve safely converted into UTF-8")
+    );
+    println!("{}", written_contents);
+
+    Ok(())
+}


### PR DESCRIPTION
Refs #6 

### 実行結果

```bash
💻 sho.nakatani@mbp2019 📂 ~/.ghq/src/github.com/yuk1ty/learning-systems-programming-in-rust ⏰ 21:38:35
% cargo run --bin 2_8_1
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/2_8_1`
Written to '/var/folders/6b/m27gbqp15ddc90cyj1r3bvjc0000gn/T/1619786316-232845000' :
{}("10"): 10, {}(10): 10, {:.1}(10.0): 10.0

```