### PR TITLE
add 3.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +152,7 @@ dependencies = [
  "httparse",
  "lib",
  "rand",
+ "scan_fmt",
  "zip",
 ]
 
@@ -234,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +327,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
+dependencies = [
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,15 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,7 +143,6 @@ dependencies = [
  "httparse",
  "lib",
  "rand",
- "scan_fmt",
  "zip",
 ]
 
@@ -244,12 +234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
-name = "memchr"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,32 +311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "scan_fmt"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
-dependencies = [
- "regex",
 ]
 
 [[package]]

--- a/chapter3/Cargo.toml
+++ b/chapter3/Cargo.toml
@@ -13,6 +13,7 @@ zip = "0.5.12"
 lib = { path = "../lib" }
 httparse = "1.3.5"
 anyhow = "1.0.40"
+scan_fmt = "0.2.6"
 
 [[bin]]
 name = "main_3_1"
@@ -50,3 +51,6 @@ path = "src/3_6_1/main.rs"
 [[bin]]
 name = "3_6_3"
 path = "src/3_6_3/main.rs"
+[[bin]]
+name = "3_6_2"
+path = "src/3_6_2/main.rs"

--- a/chapter3/Cargo.toml
+++ b/chapter3/Cargo.toml
@@ -13,7 +13,6 @@ zip = "0.5.12"
 lib = { path = "../lib" }
 httparse = "1.3.5"
 anyhow = "1.0.40"
-scan_fmt = "0.2.6"
 
 [[bin]]
 name = "main_3_1"

--- a/chapter3/src/3_6_2/main.rs
+++ b/chapter3/src/3_6_2/main.rs
@@ -1,8 +1,8 @@
-/// Rust には scanf 関数はない。したがって、この節は本来は実装できない。
-/// Rust のマクロを使用すると scanf に近い実装を作ることができるので、参考程度に実装しておく。
-/// マクロを自前実装する以外の選択肢としては、下記のようなクレートを使用する手もある。
-/// - [text_io](https://github.com/oli-obk/rust-si): scan マクロが存在する。
-/// - [scan_fmt](https://github.com/wlentz/scan_fmt): 同様に scan_fmt マクロが存在する。
+//! Rust には scanf 関数はない。したがって、この節は本来は実装できない。
+//! Rust のマクロを使用すると scanf に近い実装を作ることができるので、参考程度に実装しておく。
+//! マクロを自前実装する以外の選択肢としては、下記のようなクレートを使用する手もある。
+//! - [text_io](https://github.com/oli-obk/rust-si): scan マクロが存在する。
+//! - [scan_fmt](https://github.com/wlentz/scan_fmt): 同様に scan_fmt マクロが存在する。
 
 /// scan! マクロ。
 /// scan!("<入れた文字>", セパレータの設定, 型情報*) と値を入れていくと、scanf とほぼ同等の動きをする。
@@ -20,8 +20,7 @@ macro_rules! scan {
 
 const SOURCE: &str = "123 1.234 1.0e4 test";
 
-fn main() -> std::io::Result<()> {
+fn main() {
     let (i, f, g, s) = scan!(SOURCE, char::is_whitespace, i32, f64, f64, String);
     println!("i={} f={} g={} s={}", i, f, g, s);
-    Ok(())
 }

--- a/chapter3/src/3_6_2/main.rs
+++ b/chapter3/src/3_6_2/main.rs
@@ -4,6 +4,13 @@
 /// - [text_io](https://github.com/oli-obk/rust-si): scan マクロが存在する。
 /// - [scan_fmt](https://github.com/wlentz/scan_fmt): 同様に scan_fmt マクロが存在する。
 
+/// scan! マクロ。
+/// scan!("<入れた文字>", セパレータの設定, 型情報*) と値を入れていくと、scanf とほぼ同等の動きをする。
+///
+/// Example:
+/// ```rust
+/// scan!("123 text", char::is_whitespacce, i32, String);
+/// ```
 macro_rules! scan {
     ( $string:expr, $sep:expr, $( $x:ty ),+ ) => {{
         let mut iter = $string.split($sep);

--- a/chapter3/src/3_6_2/main.rs
+++ b/chapter3/src/3_6_2/main.rs
@@ -1,0 +1,20 @@
+/// Rust には scanf 関数はない。したがって、この節は本来は実装できない。
+/// Rust のマクロを使用すると scanf に近い実装を作ることができるので、参考程度に実装しておく。
+/// マクロを自前実装する以外の選択肢としては、下記のようなクレートを使用する手もある。
+/// - [text_io](https://github.com/oli-obk/rust-si): scan マクロが存在する。
+/// - [scan_fmt](https://github.com/wlentz/scan_fmt): 同様に scan_fmt マクロが存在する。
+
+macro_rules! scan {
+    ( $string:expr, $sep:expr, $( $x:ty ),+ ) => {{
+        let mut iter = $string.split($sep);
+        ($(iter.next().map(|word| word.parse::<$x>().ok().expect(&format!("couldn't parse {}", word))).unwrap(),)*)
+    }}
+}
+
+const SOURCE: &str = "123 1.234 1.0e4 test";
+
+fn main() -> std::io::Result<()> {
+    let (i, f, g, s) = scan!(SOURCE, char::is_whitespace, i32, f64, f64, String);
+    println!("i={} f={} g={} s={}", i, f, g, s);
+    Ok(())
+}


### PR DESCRIPTION
3.6.2 を実装します。Rust には `scanf` 関数はなかったはずで、実現するためにはマクロか自前で関数を定義するかといった実装が必要になります。

飛ばしてもよかったですが、参考程度に実装を用意しておきます。`Reader` を使えてないので、あまりいい実装ではないかもしれません。他にいい手をご存知の方いらっしゃいましたら教えて下さい🙇‍♀️

## Go のコード
- https://play.golang.org/p/NY4io1CvALw