### PR TITLE
4.3.1: signal-hook の Signals イテレータを使い、SIGINTを待受けて終了するプログラム

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,10 @@ dependencies = [
 [[package]]
 name = "chapter4"
 version = "0.1.0"
+dependencies = [
+ "lib",
+ "signal-hook",
+]
 
 [[package]]
 name = "chapter5"
@@ -374,6 +378,25 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,10 +26,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "bzip2"
@@ -154,6 +166,7 @@ version = "0.1.0"
 dependencies = [
  "lib",
  "signal-hook",
+ "tokio",
 ]
 
 [[package]]
@@ -237,10 +250,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "httparse"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+
+[[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "itoa"
@@ -259,6 +290,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +321,37 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -286,6 +372,53 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pkg-config"
@@ -358,10 +491,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -398,6 +546,12 @@ checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "syn"
@@ -438,6 +592,37 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,6 @@ name = "chapter4"
 version = "0.1.0"
 dependencies = [
  "lib",
- "signal-hook",
  "tokio",
 ]
 
@@ -526,16 +525,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]

--- a/chapter4/Cargo.toml
+++ b/chapter4/Cargo.toml
@@ -7,3 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lib = { path = "../lib" }
+signal-hook = "0.3"
+
+[[bin]]
+name = "4_3_1"
+path = "src/4_3_1/main.rs"

--- a/chapter4/Cargo.toml
+++ b/chapter4/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 lib = { path = "../lib" }
 signal-hook = "0.3"
+tokio = { version = "1.5.0", features = ["full"] }
 
 [[bin]]
 name = "4_3_1"

--- a/chapter4/Cargo.toml
+++ b/chapter4/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 lib = { path = "../lib" }
-signal-hook = "0.3"
 tokio = { version = "1.5.0", features = ["full"] }
 
 [[bin]]

--- a/chapter4/src/4_3_1/main.rs
+++ b/chapter4/src/4_3_1/main.rs
@@ -1,23 +1,23 @@
 use std::io;
 
-use signal_hook::{consts::SIGINT, iterator::Signals};
+use tokio::signal::unix::{signal, SignalKind};
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let (sigint_tx, mut sigint_rx) = tokio::sync::mpsc::channel::<()>(1);
 
     tokio::spawn(async move {
-        let mut signals = Signals::new(&[SIGINT])?;
+        let mut sig_stream = signal(SignalKind::interrupt())?;
 
         println!("[signal thread] Waiting for SIGINT (CTRL+C)");
-        if signals.into_iter().next().is_some() {
-            tx.send(()).await.unwrap();
-        }
+        sig_stream.recv().await;
+
+        sigint_tx.send(()).await.unwrap();
         Ok::<(), io::Error>(())
     });
 
     println!("[main thread] Waiting for a message from channel");
-    let _ = rx.recv().await;
+    let _ = sigint_rx.recv().await;
     println!("[main thread] Got a message");
 
     Ok(())

--- a/chapter4/src/4_3_1/main.rs
+++ b/chapter4/src/4_3_1/main.rs
@@ -1,0 +1,14 @@
+use std::io;
+
+use signal_hook::{consts::SIGINT, iterator::Signals};
+
+fn main() -> io::Result<()> {
+    let mut signals = Signals::new(&[SIGINT])?;
+
+    println!("Waiting SIGINT (CTRL+C)");
+    if let Some(_) = signals.into_iter().next() {
+        println!("SIGINT arrived");
+    }
+
+    Ok(())
+}

--- a/chapter4/src/4_3_1/main.rs
+++ b/chapter4/src/4_3_1/main.rs
@@ -2,13 +2,23 @@ use std::io;
 
 use signal_hook::{consts::SIGINT, iterator::Signals};
 
-fn main() -> io::Result<()> {
-    let mut signals = Signals::new(&[SIGINT])?;
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
-    println!("Waiting SIGINT (CTRL+C)");
-    if let Some(_) = signals.into_iter().next() {
-        println!("SIGINT arrived");
-    }
+    tokio::spawn(async move {
+        let mut signals = Signals::new(&[SIGINT])?;
+
+        println!("[signal thread] Waiting for SIGINT (CTRL+C)");
+        if signals.into_iter().next().is_some() {
+            tx.send(()).await.unwrap();
+        }
+        Ok::<(), io::Error>(())
+    });
+
+    println!("[main thread] Waiting for a message from channel");
+    let _ = rx.recv().await;
+    println!("[main thread] Got a message");
 
     Ok(())
 }

--- a/chapter4/src/main.rs
+++ b/chapter4/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Fixes: #30 

https://github.com/yuk1ty/learning-systems-programming-in-rust/issues/30#issuecomment-831653136 で書いたことを考え、libcクレートの導入は（重たくてCIや手元ビルドを遅くするので）やめ、signal-hook クレートを使うことにしました。

システムプログラミングとしては面白みに欠けますが...

## 動作確認

```bash
% cargo run --bin 4_3_1
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/4_3_1`
Waiting SIGINT (CTRL+C)
^CSIGINT arrived
```