### PR TITLE
ci: ビルド警告でCI failするようにした & ビルド対象を all-targets , all-featurs にした。

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
+    - name: Build (denying warnings)
+      run: RUSTFLAGS='-D warnings' cargo build --all-targets --all-features --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/chapter2/src/2_8_1/main.rs
+++ b/chapter2/src/2_8_1/main.rs
@@ -34,8 +34,6 @@ fn write_fmt<W: fmt::Write>(w: &mut W) {
 }
 
 fn main() -> io::Result<()> {
-    let x = 42;
-
     let tmp_path = mktemp();
     {
         let mut contents = String::new();

--- a/chapter2/src/2_8_1/main.rs
+++ b/chapter2/src/2_8_1/main.rs
@@ -34,6 +34,8 @@ fn write_fmt<W: fmt::Write>(w: &mut W) {
 }
 
 fn main() -> io::Result<()> {
+    let x = 42;
+
     let tmp_path = mktemp();
     {
         let mut contents = String::new();


### PR DESCRIPTION
Fixes: #55 

[動作確認](https://github.com/yuk1ty/learning-systems-programming-in-rust/pull/57/checks?check_run_id=2500292329#step:3:54)もできました。

`--all-targets` をつけておくと `#[test]` やdoc中のコードも警告検出対象になります。
`--all-features` をつけておくと、特定のfeatureだけで有効なコードも警告検出対象になります。