### PR TITLE
3.5.1: lib::io::{LimitedReader, SectionReader} を追加し、それぞれを使って文字列の一部を標準出力に表示するプログラム

### DIFF
--- a/chapter3/Cargo.toml
+++ b/chapter3/Cargo.toml
@@ -30,6 +30,9 @@ path = "src/3_4_3/main.rs"
 name = "3_4_4"
 path = "src/3_4_4/main.rs"
 [[bin]]
+name = "3_5_1"
+path = "src/3_5_1/main.rs"
+[[bin]]
 name = "3_9_1"
 path = "src/3_9_1/main.rs"
 [[bin]]

--- a/chapter3/src/3_5_1/main.rs
+++ b/chapter3/src/3_5_1/main.rs
@@ -1,0 +1,21 @@
+use std::{
+    fs::OpenOptions,
+    io::{self, Write},
+};
+
+use lib::{env::temp_file, io::SectionReader};
+
+fn main() -> io::Result<()> {
+    // File implements both Read & Seek
+    let mut f = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .read(true)
+        .open(temp_file())?;
+    writeln!(f, "Example of io.SectionReader")?;
+
+    let mut reader = SectionReader::new(f, 14, 7)?;
+    io::copy(&mut reader, &mut io::stdout())?;
+
+    Ok(())
+}

--- a/chapter3/src/3_5_1/main.rs
+++ b/chapter3/src/3_5_1/main.rs
@@ -35,7 +35,7 @@ fn main() -> io::Result<()> {
     let f1 = create_read_write_temp_file("Example of io.SectionReader")?;
     section_reader(f1)?;
 
-    println!("");
+    println!();
 
     let f2 = create_read_write_temp_file("Example of io.LimitedReader")?;
     limited_reader(f2)?;

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -1,3 +1,5 @@
 mod multi_writer;
+mod section_reader;
 
 pub use multi_writer::MultiWriter;
+pub use section_reader::SectionReader;

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -1,5 +1,7 @@
+mod limited_reader;
 mod multi_writer;
 mod section_reader;
 
+pub use limited_reader::LimitedReader;
 pub use multi_writer::MultiWriter;
 pub use section_reader::SectionReader;

--- a/lib/src/io/limited_reader.rs
+++ b/lib/src/io/limited_reader.rs
@@ -1,0 +1,54 @@
+use std::io::{self, Read, Seek};
+
+use super::SectionReader;
+
+/// Reads only limited bytes of given reader from start.
+/// Useful to read header section of a binary file, for example.
+///
+/// # Examples
+///
+/// ```
+/// use lib::{env::temp_file, io::LimitedReader};
+/// use std::{fs::OpenOptions, io::{self, Read, Write}};
+///
+/// fn main() -> io::Result<()> {
+///     let mut f = OpenOptions::new()
+///         .create(true)
+///         .write(true)
+///         .read(true)
+///         .open(temp_file())?;
+///     writeln!(f, "Example of io.LimitedReader")?;
+///
+///     let mut reader = LimitedReader::new(f, 7)?;
+///     let mut s = String::new();
+///     reader.read_to_string(&mut s)?;
+///     assert_eq!(&s, "Example");
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug)]
+pub struct LimitedReader<R>(SectionReader<R>)
+where
+    R: Read + Seek;
+
+impl<R> LimitedReader<R>
+where
+    R: Read + Seek,
+{
+    /// Constructs new LimitedReader that reads bytes
+    /// from start to `min(n_byte, EOF)` from `reader`.
+    pub fn new(reader: R, n_byte: usize) -> io::Result<Self> {
+        let section_reader = SectionReader::new(reader, 0, n_byte)?;
+        Ok(Self(section_reader))
+    }
+}
+
+impl<R> Read for LimitedReader<R>
+where
+    R: Read + Seek,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}

--- a/lib/src/io/section_reader.rs
+++ b/lib/src/io/section_reader.rs
@@ -1,0 +1,75 @@
+use std::io::{self, Read, Seek, SeekFrom};
+
+/// Reads only limited section (bytes window) of given reader.
+/// Useful to read part of a binary file, for example.
+///
+/// # Examples
+///
+/// ```
+/// use lib::{env::temp_file, io::SectionReader};
+/// use std::{fs::OpenOptions, io::{self, Read, Write}};
+///
+/// fn main() -> io::Result<()> {
+///     let mut f = OpenOptions::new()
+///         .create(true)
+///         .write(true)
+///         .read(true)
+///         .open(temp_file())?;
+///     writeln!(f, "Example of io.SectionReader")?;
+///
+///     let mut reader = SectionReader::new(f, 14, 7)?;
+///     let mut s = String::new();
+///     reader.read_to_string(&mut s)?;
+///     assert_eq!(&s, "Section");
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug)]
+pub struct SectionReader<R>
+where
+    R: Read + Seek,
+{
+    seeked_reader: R,
+    reads_upto: usize,
+}
+
+impl<R> SectionReader<R>
+where
+    R: Read + Seek,
+{
+    /// Constructs new SectionReader that reads bytes
+    /// in range `[offset_byte, min(offset_byte + n_byte, EOF)]` from `reader`.
+    pub fn new(mut reader: R, offset_byte: u64, n_byte: usize) -> io::Result<Self> {
+        reader.seek(SeekFrom::Start(offset_byte))?;
+        Ok(Self {
+            seeked_reader: reader,
+            reads_upto: n_byte,
+        })
+    }
+}
+
+impl<R> Read for SectionReader<R>
+where
+    R: Read + Seek,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.reads_upto == 0 {
+            Ok(0) // pseudo EOF
+        } else {
+            let read_byes = self.seeked_reader.read(buf)?;
+            if read_byes == 0 {
+                // got EOF
+                Ok(0)
+            } else if read_byes <= self.reads_upto {
+                self.reads_upto -= read_byes;
+                Ok(read_byes)
+            } else {
+                // actually read `read_bytes` but pretend to did just `reads_upto` bytes.
+                let ret = self.reads_upto;
+                self.reads_upto = 0;
+                Ok(ret)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 対象の Issue

Refs: #13 

## 動作確認結果

### Go

プログラム: https://play.golang.org/p/gpxHDVLKjWV

```
Section
Example of io.Se
```

### Rust

```bash
% cargo run --bin 3_5_1
   Compiling chapter3 v0.1.0 (/Users/sho.nakatani/.ghq/src/github.com/yuk1ty/learning-systems-programming-in-rust/chapter3)
    Finished dev [unoptimized + debuginfo] target(s) in 0.91s
     Running `target/debug/3_5_1`
Section
Example of io.Li
```

（出力が `... io.Se` と `... io.Li` と異なっているのは、Goの方はLimitedReaderを使っている方でもSectionReaderを使ってる風な文字列を流用しているからです）