### PR TITLE
added 9.2.1, 9.2.3

### DIFF
--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -8,3 +8,11 @@ edition = "2018"
 
 [dependencies]
 lib = { path = "../lib" }
+
+[[bin]]
+name = "main_9_2_1"
+path = "src/main_9_2_1.rs"
+
+[[bin]]
+name = "main_9_2_3"
+path = "src/main_9_2_3.rs"

--- a/chapter9/src/main.rs
+++ b/chapter9/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/chapter9/src/main_9_2_1.rs
+++ b/chapter9/src/main_9_2_1.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::io::{self, Write};
+
+//ファイル作成/読み込み
+
+// 新規作成
+fn open() -> std::io::Result<()> {
+    let mut file = fs::File::create("textfile.txt")?;
+    file.write_all(b"New file content\n")?;
+    Ok(())
+}
+
+// 読み込み
+fn read() -> std::io::Result<()> {
+    let mut file = fs::File::open("textfile.txt")?;
+    println!("Read file:");
+    io::copy(&mut file, &mut io::stdout())?;
+    Ok(())
+}
+
+// 追記モード
+fn append() -> std::io::Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .append(true)
+        .open("textfile.txt")?;
+    file.write_all(b"Appened content\n")?;
+    Ok(())
+}
+
+fn main() -> std::io::Result<()> {
+    open()?;
+    read()?;
+    append()?;
+    read()?;
+    Ok(())
+}

--- a/chapter9/src/main_9_2_3.rs
+++ b/chapter9/src/main_9_2_3.rs
@@ -1,0 +1,10 @@
+use std::fs;
+
+fn main() -> std::io::Result<()> {
+    // フォルダを1階層だけ作成
+    fs::create_dir("setting")?;
+
+    // 深いフォルダを1回で作成
+    fs::create_dir_all("setting/myapp/networksettings")?;
+    Ok(())
+}


### PR DESCRIPTION
## 対象の Issue

`9.2 節をリプレースする` https://github.com/yuk1ty/learning-systems-programming-in-rust/issues/59

## 動作確認結果

### golang版動作 9.2.1

```bash
$ go version
go version go1.16.3 darwin/amd64
```
learn-system-programming-with-go/ch9/s2-1

※ golang版には`contentt` というtypoがあるので、そこはそのままです。 Rust版では修正しています。

```bash
$ ./s2-1
Read file:
New file contentt
Read file:
New file contentt
Appened content
```

作成されたファイル
```bash
$ cat textfile.txt
New file contentt
Appened content
```

### Rust版動作確認 9.2.1

```bash
$ rustc --version
rustc 1.51.0 (2fd73fabe 2021-03-23)
```
```bash
$ cargo run --bin main_9_2_1
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `~/tr/learning-systems-programming-in-rust/target/debug/main_9_2_1`
Read file:
New file content
Read file:
New file content
Appened content
```

作成されたファイル
```bash
$ cat textfile.txt
New file content
Appened content
```

### golang版動作 9.2.3

```bash
$ ./s2-2
```

./setting 以下のディレクトリ作成を確認

```bash
$ find .
.
./s2-2
./setting
./setting/myapp
./setting/myapp/networksettings
./main.go
```

### Rust版動作確認 9.2.3

```bash
$ cargo run --bin main_9_2_3
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `~/tr/learning-systems-programming-in-rust/target/debug/main_9_2_3`
```

./setting 以下のディレクトリ作成を確認

```bash
$ find .
.
./Cargo.toml
./textfile.txt
./setting
./setting/myapp
./setting/myapp/networksettings
./src
./src/main_9_2_3.rs
./src/main_9_2_1.rs
```
