### PR TITLE
3.5.2: lib::binary::read (新実装) を使い、エンディアンを指定してバイト列を整数型に読込むプログラム

### DIFF
--- a/chapter3/Cargo.toml
+++ b/chapter3/Cargo.toml
@@ -30,6 +30,9 @@ path = "src/3_4_3/main.rs"
 name = "3_4_4"
 path = "src/3_4_4/main.rs"
 [[bin]]
+name = "3_5_2"
+path = "src/3_5_2/main.rs"
+[[bin]]
 name = "3_9_1"
 path = "src/3_9_1/main.rs"
 [[bin]]

--- a/chapter3/src/3_5_2/main.rs
+++ b/chapter3/src/3_5_2/main.rs
@@ -1,0 +1,14 @@
+use lib::binary;
+use std::io;
+
+fn main() -> io::Result<()> {
+    let mut bytes: &[u8] = &[0x0, 0x0, 0x27, 0x10];
+    let n_big: u32 = binary::read(&mut bytes, &binary::Endian::BigEndian)?;
+    println!("Big endian: {}", n_big);
+
+    let mut bytes: &[u8] = &[0x0, 0x0, 0x27, 0x10];
+    let n_little: u32 = binary::read(&mut bytes, &binary::Endian::LittleEndian)?;
+    println!("Little endian: {}", n_little);
+
+    Ok(())
+}

--- a/lib/src/binary.rs
+++ b/lib/src/binary.rs
@@ -1,0 +1,49 @@
+mod endian;
+mod fixed_len_bytes;
+
+pub use endian::Endian;
+pub use fixed_len_bytes::FixedLenBytes;
+
+use std::io::{self, Read};
+
+/// Read bytes of fixed size (`B::len()`) from `reader` in `endian` order.
+///
+/// # Examples
+///
+/// ```
+/// use lib::binary;
+/// use std::io;
+///
+/// fn main() -> io::Result<()> {
+///     let mut bytes: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+///     let n_big: u32 = binary::read(&mut bytes, &binary::Endian::BigEndian)?;
+///     assert_eq!(n_big, 0x01020304);
+///
+///     let mut bytes: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+///     // reads only first 2 bytes
+///     let n_little: u16 = binary::read(&mut bytes, &binary::Endian::LittleEndian)?;
+///     assert_eq!(n_little, 0x0201);
+///
+///     Ok(())
+/// }
+/// ```
+pub fn read<R, B>(reader: &mut R, endian: &Endian) -> io::Result<B>
+where
+    R: Read,
+    B: FixedLenBytes,
+{
+    let mut buf = Vec::<u8>::new();
+    buf.resize(B::len(), 0);
+
+    reader.read_exact(&mut buf)?;
+
+    match endian {
+        Endian::BigEndian => {}
+        Endian::LittleEndian => {
+            buf.reverse();
+        }
+    }
+
+    let bytes = B::new(&buf).expect("buf has wrong length");
+    Ok(bytes)
+}

--- a/lib/src/binary/endian.rs
+++ b/lib/src/binary/endian.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Endian {
+    BigEndian,
+    LittleEndian,
+}

--- a/lib/src/binary/fixed_len_bytes.rs
+++ b/lib/src/binary/fixed_len_bytes.rs
@@ -1,0 +1,72 @@
+use std::{array::TryFromSliceError, convert::TryInto};
+
+/// Represents data types whose size are fixed.
+pub trait FixedLenBytes {
+    /// Length in bytes
+    fn len() -> usize;
+
+    /// Construct from byte sequence (in big endian).
+    ///
+    /// # Failures
+    ///
+    /// `TryFromSliceError` when `buf.len() != Self::len()`.
+    fn new(buf: &[u8]) -> Result<Self, TryFromSliceError>
+    where
+        Self: Sized;
+}
+
+impl FixedLenBytes for u8 {
+    fn len() -> usize {
+        1
+    }
+
+    fn new(buf: &[u8]) -> Result<Self, TryFromSliceError>
+    where
+        Self: Sized,
+    {
+        let arr = buf.try_into()?;
+        Ok(Self::from_be_bytes(arr))
+    }
+}
+
+impl FixedLenBytes for u16 {
+    fn len() -> usize {
+        2
+    }
+
+    fn new(buf: &[u8]) -> Result<Self, TryFromSliceError>
+    where
+        Self: Sized,
+    {
+        let arr = buf.try_into()?;
+        Ok(Self::from_be_bytes(arr))
+    }
+}
+
+impl FixedLenBytes for u32 {
+    fn len() -> usize {
+        4
+    }
+
+    fn new(buf: &[u8]) -> Result<Self, TryFromSliceError>
+    where
+        Self: Sized,
+    {
+        let arr = buf.try_into()?;
+        Ok(Self::from_be_bytes(arr))
+    }
+}
+
+impl FixedLenBytes for u64 {
+    fn len() -> usize {
+        8
+    }
+
+    fn new(buf: &[u8]) -> Result<Self, TryFromSliceError>
+    where
+        Self: Sized,
+    {
+        let arr = buf.try_into()?;
+        Ok(Self::from_be_bytes(arr))
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod binary;
 pub mod env;
 pub mod io;


### PR DESCRIPTION
## 対象の Issue

Refs: #13 

## 動作確認結果

### Go

https://play.golang.org/p/hDbP6-yBHj4q

```
data: 10000
```

### Rust

```
Big endian: 10000
Little endian: 270991360
```

(GoではLittle endianのほうは表示していないがこちらでは表示)