### PR TITLE
add 9.5.1 - 9.5.3

### DIFF
--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2018"
 
 [dependencies]
 lib = { path = "../lib" }
+
+[[bin]]
+name = "9_5_1"
+path = "src/9_5_1/main.rs"

--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -16,3 +16,7 @@ path = "src/9_5_1/main.rs"
 [[bin]]
 name = "9_5_2"
 path = "src/9_5_2/main.rs"
+
+[[bin]]
+name = "9_5_3"
+path = "src/9_5_3/main.rs"

--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -12,3 +12,7 @@ lib = { path = "../lib" }
 [[bin]]
 name = "9_5_1"
 path = "src/9_5_1/main.rs"
+
+[[bin]]
+name = "9_5_2"
+path = "src/9_5_2/main.rs"

--- a/chapter9/src/9_5_1/main.rs
+++ b/chapter9/src/9_5_1/main.rs
@@ -1,0 +1,12 @@
+use std::env::temp_dir;
+
+// ディレクトリのパスとファイル名とを連結する
+fn main() {
+    println!(
+        "Temp File Path: {}",
+        temp_dir()
+            .join("temp.txt")
+            .to_str()
+            .expect("failed to convert to str")
+    );
+}

--- a/chapter9/src/9_5_2/main.rs
+++ b/chapter9/src/9_5_2/main.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+fn main() {
+    let path = Path::new("/folder1/folder2/example.txt");
+
+    // Path/PathBufでは末尾と親をそれぞれ取得することができる
+    let dir = path.parent().and_then(|d| d.to_str()).unwrap_or("");
+    let name = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+    println!("Dir: {}, Name: {}", dir, name);
+
+    // componentsでパスを分割できる。
+    let components: Vec<_> = path.components().map(|c| c.as_os_str()).collect();
+    println!("{:?}", components);
+
+    // file_nameはパスの最後の要素を返す
+    println!("{}", name);
+
+    // parentはパスのディレクトリ部分を返す
+    println!("{}", dir);
+
+    // extensionはフアイルの拡張子を返す
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    println!("{}", ext);
+}

--- a/chapter9/src/9_5_3/main.rs
+++ b/chapter9/src/9_5_3/main.rs
@@ -11,21 +11,16 @@ fn main() {
         exit(1);
     }
 
-    match env::var_os("PATH") {
-        Some(paths) => {
-            for path in env::split_paths(&paths) {
-                let exec_path = path.join(&args[1]);
-                if exec_path.exists() {
-                    println!("{}", exec_path.to_str().expect("faled to convert to str"));
-                    return;
-                }
-            }
-        }
-        None => {
-            println!("failed to get PATH");
-            exit(1)
-        }
-    }
-
-    exit(1);
+    let paths = env::var_os("PATH").expect("failed to get PATH");
+    env::split_paths(&paths)
+        .find_map(|path| {
+            let exec_path = path.join(&args[1]);
+            exec_path.exists().then(|| exec_path)
+        })
+        .map_or_else(
+            || exit(1),
+            |exec_path| {
+                println!("{}", exec_path.to_str().expect("faled to convert to str"));
+            },
+        );
 }

--- a/chapter9/src/9_5_3/main.rs
+++ b/chapter9/src/9_5_3/main.rs
@@ -1,0 +1,31 @@
+use std::env;
+use std::process::exit;
+
+// whichコマンド
+// PATH環境変数のパス一覧を取得してきて、split_pathsで分割
+// その後、各パスの下に最初の引数で指定された実行ファイルがあるかをチェック
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 1 {
+        println!("{} [exec file name]", args[0]);
+        exit(1);
+    }
+
+    match env::var_os("PATH") {
+        Some(paths) => {
+            for path in env::split_paths(&paths) {
+                let exec_path = path.join(&args[1]);
+                if exec_path.exists() {
+                    println!("{}", exec_path.to_str().expect("faled to convert to str"));
+                    return;
+                }
+            }
+        }
+        None => {
+            println!("failed to get PATH");
+            exit(1)
+        }
+    }
+
+    exit(1);
+}

--- a/chapter9/src/main.rs
+++ b/chapter9/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
## 対象の Issue
#60 9.5.1 - 9.5.3

## 動作確認結果

### 9.5.1
#### Go 実行結果

```
> go run main.go
Temp File Path: /tmp/temp.txt
```

#### Rust 実行結果

```
> cargo run -p chapter9 --bin 9_5_1
Temp File Path: /tmp/temp.txt
```

### 9.5.2 
#### Go 実行結果

```
> go run main.go
Dir: /folder1/folder2/, Name: example.txt
[ folder1 folder2 example.txt]
example.txt
/folder1/folder2
.txt
```

#### Rust 実行結果

```
> cargo run -p chapter9 --bin 9_5_2
Dir: /folder1/folder2, Name: example.txt
["/", "folder1", "folder2", "example.txt"]
example.txt
/folder1/folder2
txt
```

### 9.5.3 
#### Go 実行結果

```
存在しないパターン
> go run main.go hoge
exit status 1
> echo $?
1

存在するパターン
> go run main.go go
/usr/local/go/bin/go
```

#### Rust 実行結果

```
存在しないパターン
> cargo run -p chapter9 --bin 9_5_3 hoge
> echo $?
1

存在するパターン
> cargo run -p chapter9 --bin 9_5_3 go
/usr/local/go/bin/go
```
