### PR TITLE
3.5.3: PNGファイルのチャンクのサマリ情報を出力するプログラム

### DIFF
--- a/chapter3/Cargo.toml
+++ b/chapter3/Cargo.toml
@@ -51,11 +51,14 @@ path = "src/3_4_3/main.rs"
 name = "3_4_4"
 path = "src/3_4_4/main.rs"
 [[bin]]
+name = "3_5_1"
+path = "src/3_5_1/main.rs"
+[[bin]]
 name = "3_5_2"
 path = "src/3_5_2/main.rs"
 [[bin]]
-name = "3_5_1"
-path = "src/3_5_1/main.rs"
+name = "3_5_3"
+path = "src/3_5_3/main.rs"
 [[bin]]
 name = "3_9_1"
 path = "src/3_9_1/main.rs"

--- a/chapter3/src/3_5_3/main.rs
+++ b/chapter3/src/3_5_3/main.rs
@@ -1,0 +1,21 @@
+use std::{env, fs::File, io};
+
+use png::PngAnalyzer;
+
+mod png;
+
+fn main() -> io::Result<()> {
+    let png_path: String = {
+        let mut args = env::args();
+        let _ = args.next();
+        args.next()
+            .expect("pass PNG file path as command line option")
+    };
+
+    let png = File::open(png_path)?;
+    let analyzer = PngAnalyzer::new(png);
+    for chunk in analyzer.chunks() {
+        println!("{}", chunk);
+    }
+    Ok(())
+}

--- a/chapter3/src/3_5_3/png.rs
+++ b/chapter3/src/3_5_3/png.rs
@@ -1,0 +1,5 @@
+mod png_analyzer;
+mod png_chunks;
+
+pub use png_analyzer::PngAnalyzer;
+pub use png_chunks::{PngChunk, PngChunkType, PngChunks};

--- a/chapter3/src/3_5_3/png/png_analyzer.rs
+++ b/chapter3/src/3_5_3/png/png_analyzer.rs
@@ -1,0 +1,39 @@
+use std::io::Read;
+
+use super::PngChunks;
+
+#[derive(Debug)]
+pub struct PngAnalyzer<R>
+where
+    R: Read,
+{
+    png_reader: R,
+}
+
+impl<R> PngAnalyzer<R>
+where
+    R: Read,
+{
+    pub fn new(png_reader: R) -> Self {
+        Self { png_reader }
+    }
+
+    pub fn chunks(mut self) -> PngChunks<R> {
+        self.read_signature();
+        PngChunks::new(self.png_reader)
+    }
+
+    /// # Panics
+    ///
+    /// - Leading 8 bytes do not match PNG file signature.
+    /// - Got any io::Error internally.
+    fn read_signature(&mut self) {
+        let mut sig = [0u8; 8];
+        self.png_reader.read_exact(&mut sig).unwrap();
+        assert_eq!(
+            sig,
+            [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+            "wrong PNG file signature"
+        );
+    }
+}

--- a/chapter3/src/3_5_3/png/png_chunks.rs
+++ b/chapter3/src/3_5_3/png/png_chunks.rs
@@ -1,0 +1,36 @@
+mod png_chunk;
+
+use std::io::Read;
+
+pub use png_chunk::{PngChunk, PngChunkType};
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct PngChunks<R>
+where
+    R: Read,
+{
+    reader_at_next_chunk: R,
+}
+
+impl<R> PngChunks<R>
+where
+    R: Read,
+{
+    pub fn new(reader_at_first_chunk: R) -> Self {
+        Self {
+            reader_at_next_chunk: reader_at_first_chunk,
+        }
+    }
+}
+
+impl<R> Iterator for PngChunks<R>
+where
+    R: Read,
+{
+    type Item = PngChunk;
+
+    fn next(&mut self) -> Option<PngChunk> {
+        PngChunk::from_reader(&mut self.reader_at_next_chunk)
+            .expect("IO error while reading PNG chunks")
+    }
+}

--- a/chapter3/src/3_5_3/png/png_chunks/png_chunk.rs
+++ b/chapter3/src/3_5_3/png/png_chunks/png_chunk.rs
@@ -1,0 +1,93 @@
+mod png_chunk_type;
+
+use std::{
+    fmt::Display,
+    io::{self, Read},
+};
+
+pub use png_chunk_type::PngChunkType;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct PngChunk {
+    len: u32,
+    typ: PngChunkType,
+    crc: [u8; 4],
+    data: Vec<u8>,
+}
+
+impl PngChunk {
+    /// # Returns
+    ///
+    /// None when `r` points to EOF
+    pub(super) fn from_reader<R>(r: &mut R) -> io::Result<Option<Self>>
+    where
+        R: Read,
+    {
+        match Self::read_len(r) {
+            Err(e) => match e.kind() {
+                io::ErrorKind::UnexpectedEof => Ok(None),
+                _ => Err(e),
+            },
+            Ok(len) => {
+                let typ = Self::read_type(r)?;
+                let data = Self::read_data(r, len)?;
+                let crc = Self::read_crc(r)?;
+                Ok(Some(Self {
+                    len,
+                    typ,
+                    crc,
+                    data,
+                }))
+            }
+        }
+    }
+
+    fn read_len<R>(r: &mut R) -> io::Result<u32>
+    where
+        R: Read,
+    {
+        let mut buf = [0u8; 4];
+        r.read_exact(&mut buf)?;
+        Ok(u32::from_be_bytes(buf))
+    }
+
+    fn read_type<R>(r: &mut R) -> io::Result<PngChunkType>
+    where
+        R: Read,
+    {
+        let mut buf = [0u8; 4];
+        r.read_exact(&mut buf)?;
+        Ok(PngChunkType::new(buf))
+    }
+
+    fn read_data<R>(r: &mut R, len: u32) -> io::Result<Vec<u8>>
+    where
+        R: Read,
+    {
+        let mut buf = Vec::<u8>::new();
+        buf.resize(len as usize, 0);
+        r.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    fn read_crc<R>(r: &mut R) -> io::Result<[u8; 4]>
+    where
+        R: Read,
+    {
+        let mut buf = [0u8; 4];
+        r.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+}
+
+impl Display for PngChunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Chunk type: {}, Data len: {}, CRC: {:#X}",
+            self.typ,
+            self.len,
+            u32::from_be_bytes(self.crc)
+        )
+    }
+}

--- a/chapter3/src/3_5_3/png/png_chunks/png_chunk/png_chunk_type.rs
+++ b/chapter3/src/3_5_3/png/png_chunks/png_chunk/png_chunk_type.rs
@@ -1,0 +1,18 @@
+use std::fmt::Display;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct PngChunkType([u8; 4]);
+
+impl PngChunkType {
+    pub(super) fn new(data: [u8; 4]) -> Self {
+        Self(data)
+    }
+}
+
+impl Display for PngChunkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let type_str = String::from_utf8(self.0.to_vec())
+            .expect("PNG's chunk types are in 4-byte printable ASCII.");
+        write!(f, "{}", type_str)
+    }
+}


### PR DESCRIPTION
## 対象の Issue

Refs: #13

## 動作確認結果

画像ファイルは https://upload.wikimedia.org/wikipedia/en/7/7d/Lenna_%28test_image%29.png を使用。

### Go

https://github.com/yurakawa/learn-system-programming-with-go/blob/master/ch3/s5-3/main.go

```
chunk 'IHDR' (13 bytes)
chunk 'sRGB' (1 bytes)
chunk 'IDAT' (473761 bytes)
chunk 'IEND' (0 bytes)
```

### Rust

```bash
%  cargo run --bin 3_5_3 ~/Downloads/Lenna.png
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/3_5_3 /Users/sho.nakatani/Downloads/Lenna.png`
Chunk type: IHDR, Data len: 13, CRC: 0x7B1A43AD
Chunk type: sRGB, Data len: 1, CRC: 0xAECE1CE9
Chunk type: IDAT, Data len: 473761, CRC: 0xA5461538
Chunk type: IEND, Data len: 0, CRC: 0xAE426082
```

Rustの方ではCRCも出力しています。