### PR TITLE
10.2: `nix::fcntl::flock()` を使って `Cargo.toml` に排他ロックを掛け、10秒sleepするプログラム

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +82,7 @@ name = "chapter10"
 version = "0.1.0"
 dependencies = [
  "lib",
+ "nix",
 ]
 
 [[package]]
@@ -262,6 +269,18 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/chapter10/Cargo.toml
+++ b/chapter10/Cargo.toml
@@ -8,3 +8,8 @@ edition = "2018"
 
 [dependencies]
 lib = { path = "../lib" }
+nix = "0.20.0"
+
+[[bin]]
+name = "10_2"
+path = "src/10_2/main.rs"

--- a/chapter10/src/10_2/main.rs
+++ b/chapter10/src/10_2/main.rs
@@ -1,0 +1,22 @@
+use std::{thread, time};
+
+use nix::{fcntl, sys};
+
+fn main() -> nix::Result<()> {
+    let fd = fcntl::open(
+        "Cargo.toml",
+        fcntl::OFlag::O_RDONLY,
+        sys::stat::Mode::empty(),
+    )?;
+
+    println!("try locking...");
+    fcntl::flock(fd, fcntl::FlockArg::LockExclusive)?;
+    println!("locked!");
+
+    thread::sleep(time::Duration::from_secs(10));
+
+    fcntl::flock(fd, fcntl::FlockArg::Unlock)?;
+    println!("unlock");
+
+    Ok(())
+}

--- a/chapter10/src/main.rs
+++ b/chapter10/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
## 対象の Issue

Fixes: #78 

## 動作確認結果

期待出力がわかりやすいので、Goの方は動作確認していません 🙇 

### Rust

コンソール1:

```bash
%  cargo run --bin 10_2
try locking...
locked!  <- ここまで一気に出る。この時点でコンソール2でも起動。
unlock  <- 10秒後に出る。
```

コンソール2:

```bash
%  cargo run --bin 10_2
try locking...  <- ここでしばらく止まる。
locked!  <- コンソール1が終わったら出る。
unlock  <- コンソール2でロックを取得してから10秒後に出る。
```
