### PR TITLE
7.3: UDPマルチキャストで10秒おきに時刻を送るサーバとそれを受けるクライアント

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
 name = "chapter7"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "lib",
 ]
 

--- a/chapter7/Cargo.toml
+++ b/chapter7/Cargo.toml
@@ -1,10 +1,18 @@
 [package]
-name = "chapter7"
-version = "0.1.0"
 authors = ["yuk1ty <yuki.mul.tiplus@gmail.com>"]
 edition = "2018"
+name = "chapter7"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lib = { path = "../lib" }
+lib = {path = "../lib"}
+
+[[bin]]
+name = "7_3_1"
+path = "src/7_3_1/main.rs"
+
+[[bin]]
+name = "7_3_2"
+path = "src/7_3_2/main.rs"

--- a/chapter7/Cargo.toml
+++ b/chapter7/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 
 [dependencies]
 lib = {path = "../lib"}
+chrono = "0.4.19"
 
 [[bin]]
 name = "7_3_1"

--- a/chapter7/src/7_3_1/main.rs
+++ b/chapter7/src/7_3_1/main.rs
@@ -1,0 +1,16 @@
+//! Timer *server* (*sender* would be better understood).
+
+use std::net::UdpSocket;
+
+fn main() {
+    let res_addr = "0.0.0.0:0";
+    let socket = UdpSocket::bind(res_addr)
+        .unwrap_or_else(|e| panic!("failed to bind {} : {:?}", res_addr, e));
+
+    let req_addr = "224.0.0.1:9999";
+    socket
+        .connect(req_addr)
+        .unwrap_or_else(|e| panic!("failed to connect to {} : {:?}", req_addr, e));
+
+    socket.send(&[0, 1, 2]).expect("failed to send a message");
+}

--- a/chapter7/src/7_3_1/main.rs
+++ b/chapter7/src/7_3_1/main.rs
@@ -1,6 +1,10 @@
 //! Timer *server* (*sender* would be better understood).
 
-use std::net::UdpSocket;
+use std::{
+    net::UdpSocket,
+    thread,
+    time::{Duration, Instant, SystemTime},
+};
 
 fn main() {
     let res_addr = "0.0.0.0:0";
@@ -12,5 +16,14 @@ fn main() {
         .connect(req_addr)
         .unwrap_or_else(|e| panic!("failed to connect to {} : {:?}", req_addr, e));
 
-    socket.send(&[0, 1, 2]).expect("failed to send a message");
+    // sends current time per 10 secs.
+    loop {
+        let now = SystemTime::now();
+        let now_s = format!("{:?}", now);
+        println!("Tick: {:?}", &now_s);
+        socket
+            .send(now_s.as_bytes())
+            .expect("failed to send a message");
+        thread::sleep(Duration::from_secs(10));
+    }
 }

--- a/chapter7/src/7_3_1/main.rs
+++ b/chapter7/src/7_3_1/main.rs
@@ -3,8 +3,10 @@
 use std::{
     net::UdpSocket,
     thread,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, SystemTime},
 };
+
+use chrono::{DateTime, Local};
 
 fn main() {
     let res_addr = "0.0.0.0:0";
@@ -16,11 +18,15 @@ fn main() {
         .connect(req_addr)
         .unwrap_or_else(|e| panic!("failed to connect to {} : {:?}", req_addr, e));
 
+    println!("Start tick server requesting to {}", req_addr);
+
     // sends current time per 10 secs.
     loop {
         let now = SystemTime::now();
-        let now_s = format!("{:?}", now);
-        println!("Tick: {:?}", &now_s);
+        let datetime: DateTime<Local> = now.into();
+        let now_s = format!("{}", datetime.format("%d/%m/%Y %T"));
+
+        println!("Tick: {}", &now_s);
         socket
             .send(now_s.as_bytes())
             .expect("failed to send a message");

--- a/chapter7/src/7_3_2/main.rs
+++ b/chapter7/src/7_3_2/main.rs
@@ -19,12 +19,12 @@ fn main() {
         )
         .expect("failed to join multicast group");
 
-    let mut buf = [0u8; 100];
+    println!("Listen to tick server at {}", recv_addr);
 
-    println!("waiting for tick...");
-    socket.recv_from(&mut buf).expect("Didn't receive data");
-    println!("received!");
+    let mut buf = [0u8; 100];
+    let (_, recv_from_addr) = socket.recv_from(&mut buf).expect("failed to receive data");
 
     let tick_s = String::from_utf8(buf.to_vec()).expect("tick data should be written in UTF-8");
-    println!("{}", tick_s);
+    println!("Server: {}", recv_from_addr);
+    println!("Now: {}", tick_s);
 }

--- a/chapter7/src/7_3_2/main.rs
+++ b/chapter7/src/7_3_2/main.rs
@@ -19,9 +19,12 @@ fn main() {
         )
         .expect("failed to join multicast group");
 
-    let mut buf = vec![0u8, 0, 0];
-    println!("waiting for data...");
+    let mut buf = [0u8; 100];
+
+    println!("waiting for tick...");
     socket.recv_from(&mut buf).expect("Didn't receive data");
     println!("received!");
-    assert_eq!(buf, vec![0x0, 1, 2]);
+
+    let tick_s = String::from_utf8(buf.to_vec()).expect("tick data should be written in UTF-8");
+    println!("{}", tick_s);
 }

--- a/chapter7/src/7_3_2/main.rs
+++ b/chapter7/src/7_3_2/main.rs
@@ -1,0 +1,27 @@
+//! Timer *client* (*receiver* would be better understood).
+
+use std::{
+    net::{Ipv4Addr, UdpSocket},
+    str::FromStr,
+};
+
+fn main() {
+    let recv_host = "224.0.0.1";
+    let recv_addr = format!("{}:9999", recv_host);
+
+    let socket = UdpSocket::bind(&recv_addr)
+        .unwrap_or_else(|e| panic!("failed to bind {} : {:?}", recv_addr, e));
+
+    socket
+        .join_multicast_v4(
+            &Ipv4Addr::from_str(recv_host).unwrap(),
+            &Ipv4Addr::UNSPECIFIED,
+        )
+        .expect("failed to join multicast group");
+
+    let mut buf = vec![0u8, 0, 0];
+    println!("waiting for data...");
+    socket.recv_from(&mut buf).expect("Didn't receive data");
+    println!("received!");
+    assert_eq!(buf, vec![0x0, 1, 2]);
+}

--- a/chapter7/src/main.rs
+++ b/chapter7/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
## 対象の Issue

Fixes: #77 

## 動作確認結果

### Go

サーバ側:

```
 $ go run server_multicast.go ⏎
Start tick server at 224.0.0.1:9999
Tick: 2016-12-19 00:59:20.007763991 +0900 JST
Tick: 2016-12-19 00:59:30.00522309 +0900 JST
Tick: 2016-12-19 00:59:40.004806934 +0900 JST
Tick: 2016-12-19 00:59:50.005220006 +0900 JST
```

クライアント側:

```
 $ go run client_multicast.go ⏎
Listen tick server at 224.0.0.1:9999
Server 192.168.1.5:62402
Now    2016-12-19 00:59:40.004806934 +0900 JST
Server 192.168.1.5:62402
Now    2016-12-19 00:59:50.005220006 +0900 JST
```

### Rust

Goと異なる点と理由を記載します。

- Goではなるべく「HH:MM:{10, 20, 30, ...}」と10秒の境界で時刻を送出するようにしているが、Rustは起動してから10秒おきに送出
    - UDPマルチキャストが主題であり、対応方法を知らず省略した。
- 時刻の表示フォーマット
    - 主題と無関係なので chrono クレートのデフォルトの Display 実装を使った。
- クライアントがGoだと無限ループで時刻を受け続けるが、Rustだと1回受け取ったら終了する。
    - どちらでもよかったが、時刻合わせプログラムとしてはこちらのほうが自然だと思ったので。
- Goのほうは出力文字列の英語がおかしかったので正しく（自分が思えるように）修正。

サーバ側:

```
% cargo run --bin 7_3_1
Start tick server requesting to 224.0.0.1:9999
Tick: 14/05/2021 11:37:06
Tick: 14/05/2021 11:37:16
Tick: 14/05/2021 11:37:26
Tick: 14/05/2021 11:37:36
```

クライアント側:

```
% cargo run --bin 7_3_2
Listen to tick server at 224.0.0.1:9999
Server: 192.168.10.87:60892
Now: 14/05/2021 11:37:36
```