### PR TITLE
ビルド時にキャッシュするフェーズを追加する

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,14 +43,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build (denying warnings)
-        run: RUSTFLAGS='-D warnings' cargo build --all-targets --all-features --verbose
-      - name: Run tests
-        run: cargo test --verbose
+
       - uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ github.job }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Build (denying warnings)
+        run: RUSTFLAGS='-D warnings' cargo build --all-targets --all-features --verbose
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     types:
       - opened
@@ -13,39 +13,44 @@ env:
 
 jobs:
   lint:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install rust-toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        components: rustfmt, clippy
+      - name: Install rust-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy
 
-    - name: cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
-    - name: cargo clippy
-      uses: actions-rs/cargo@v1
-      env:
-        RUSTFLAGS: -D warnings
-      with:
-        command: clippy
-        args: --workspace --all-targets --all-features
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
+        with:
+          command: clippy
+          args: --workspace --all-targets --all-features
 
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build (denying warnings)
-      run: RUSTFLAGS='-D warnings' cargo build --all-targets --all-features --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - name: Build (denying warnings)
+        run: RUSTFLAGS='-D warnings' cargo build --all-targets --all-features --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,17 @@ jobs:
           profile: minimal
           components: rustfmt, clippy
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ github.job }}-
+            ${{ runner.os }}-cargo-
+
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -48,7 +59,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          components: rustfmt, clippy
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install rust-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy
+
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
そろそろ章によってはビルド時間が気になるものが出てきたので、キャッシュしてみたい。Github Actions 素人なので他にいい方法あったらコメントください。

## 計測

```
cargo +nightly build -Ztimings
```

代表的な重そうなものは下記。

tokio

![Screenshot 2021-05-15 at 12 04 04](https://user-images.githubusercontent.com/24487281/118346337-a640d580-b575-11eb-8ff4-b72c454bbcc0.png)

syn

![Screenshot 2021-05-15 at 12 04 13](https://user-images.githubusercontent.com/24487281/118346341-ab9e2000-b575-11eb-8db9-1a08e82b52ae.png)

serde

![Screenshot 2021-05-15 at 12 04 47](https://user-images.githubusercontent.com/24487281/118346349-c07ab380-b575-11eb-9930-08a9b5787c8d.png)
