### PR TITLE
Add 9.5.4 - 9.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,9 @@ dependencies = [
 name = "chapter9"
 version = "0.1.0"
 dependencies = [
+ "glob",
  "lib",
- "regex",
+ "walkdir",
 ]
 
 [[package]]
@@ -312,6 +313,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,7 @@ name = "chapter9"
 version = "0.1.0"
 dependencies = [
  "lib",
+ "regex",
 ]
 
 [[package]]
@@ -383,6 +393,8 @@ name = "lib"
 version = "0.1.0"
 dependencies = [
  "crc32fast",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -672,6 +684,23 @@ checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "ryu"

--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 lib = { path = "../lib" }
 glob = "0.3.0"
+walkdir = "2"
 
 [[bin]]
 name = "main_9_2_1"
@@ -45,3 +46,7 @@ path = "src/9_5_5/main.rs"
 [[bin]]
 name = "9_5_6"
 path = "src/9_5_6/main.rs"
+
+[[bin]]
+name = "9_5_7"
+path = "src/9_5_7/main.rs"

--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -10,6 +10,14 @@ edition = "2018"
 lib = { path = "../lib" }
 
 [[bin]]
+name = "main_9_2_1"
+path = "src/main_9_2_1.rs"
+
+[[bin]]
+name = "main_9_2_3"
+path = "src/main_9_2_3.rs"
+
+[[bin]]
 name = "main_9_2_4"
 path = "src/main_9_2_4.rs"
 
@@ -26,9 +34,6 @@ name = "9_5_3"
 path = "src/9_5_3/main.rs"
 
 [[bin]]
-name = "main_9_2_1"
-path = "src/main_9_2_1.rs"
+name = "9_5_4"
+path = "src/9_5_4/main.rs"
 
-[[bin]]
-name = "main_9_2_3"
-path = "src/main_9_2_3.rs"

--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 lib = { path = "../lib" }
+regex = "1"
 
 [[bin]]
 name = "main_9_2_1"
@@ -37,3 +38,6 @@ path = "src/9_5_3/main.rs"
 name = "9_5_4"
 path = "src/9_5_4/main.rs"
 
+[[bin]]
+name = "9_5_5"
+path = "src/9_5_5/main.rs"

--- a/chapter9/Cargo.toml
+++ b/chapter9/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 lib = { path = "../lib" }
-regex = "1"
+glob = "0.3.0"
 
 [[bin]]
 name = "main_9_2_1"
@@ -41,3 +41,7 @@ path = "src/9_5_4/main.rs"
 [[bin]]
 name = "9_5_5"
 path = "src/9_5_5/main.rs"
+
+[[bin]]
+name = "9_5_6"
+path = "src/9_5_6/main.rs"

--- a/chapter9/src/9_5_4/main.rs
+++ b/chapter9/src/9_5_4/main.rs
@@ -1,0 +1,38 @@
+use std::env;
+use std::path::{Path, PathBuf};
+#[derive(Debug)]
+enum PathError {
+    IoError(std::io::Error),
+    StripPrefixError(std::path::StripPrefixError),
+}
+
+impl From<std::io::Error> for PathError {
+    fn from(error: std::io::Error) -> Self {
+        PathError::IoError(error)
+    }
+}
+
+impl From<std::path::StripPrefixError> for PathError {
+    fn from(error: std::path::StripPrefixError) -> Self {
+        PathError::StripPrefixError(error)
+    }
+}
+
+fn main() -> Result<(), PathError> {
+    // パスをそのままクリーンにする
+    let path = PathBuf::from("./chapter9/src/../src/9_5_4/main.rs").canonicalize()?;
+    let current_dir = env::current_dir()?;
+    let clean_path = path.strip_prefix(current_dir)?;
+    println!("{:?}", clean_path);
+
+    // パスを絶対パスに整形
+    let abs_path = Path::new("./chapter9/src/9_5_4/main.rs").canonicalize()?;
+    println!("{:?}", abs_path);
+
+    // パスを相対パスに整形
+    let abs_path = Path::new("/usr/local/go/bin/go");
+    let rel_path = abs_path.strip_prefix("/usr/local/go")?;
+    println!("{:?}", rel_path);
+
+    Ok(())
+}

--- a/chapter9/src/9_5_4/main.rs
+++ b/chapter9/src/9_5_4/main.rs
@@ -1,29 +1,12 @@
-use std::env;
-use std::path::{Path, PathBuf};
-#[derive(Debug)]
-enum PathError {
-    IoError(std::io::Error),
-    StripPrefixError(std::path::StripPrefixError),
-}
-
-impl From<std::io::Error> for PathError {
-    fn from(error: std::io::Error) -> Self {
-        PathError::IoError(error)
-    }
-}
-
-impl From<std::path::StripPrefixError> for PathError {
-    fn from(error: std::path::StripPrefixError) -> Self {
-        PathError::StripPrefixError(error)
-    }
-}
+use lib::path::*;
+use std::path::Path;
 
 fn main() -> Result<(), PathError> {
+    //存在しないパスを指定した場合、エラーを返す
+
     // パスをそのままクリーンにする
-    let path = PathBuf::from("./chapter9/src/../src/9_5_4/main.rs").canonicalize()?;
-    let current_dir = env::current_dir()?;
-    let clean_path = path.strip_prefix(current_dir)?;
-    println!("{:?}", clean_path);
+    let path = Path::new("./chapter9/src/../src/9_5_4/main.rs").clean()?;
+    println!("{:?}", path);
 
     // パスを絶対パスに整形
     let abs_path = Path::new("./chapter9/src/9_5_4/main.rs").canonicalize()?;

--- a/chapter9/src/9_5_5/main.rs
+++ b/chapter9/src/9_5_5/main.rs
@@ -1,0 +1,18 @@
+use lib::path::{ExtendedPath, PathError};
+use std::path::{Path, PathBuf};
+
+fn clean2(path: &Path) -> Result<PathBuf, PathError> {
+    let path = path.expand_env()?;
+    let path = path.clean()?;
+    Ok(path)
+}
+
+fn main() -> Result<(), PathError> {
+    let path = Path::new("${HOME}/.zshrc");
+    println!("{:?}", clean2(path)?);
+
+    let path = Path::new("~/.zshrc");
+    println!("{:?}", clean2(path)?);
+
+    Ok(())
+}

--- a/chapter9/src/9_5_5/main.rs
+++ b/chapter9/src/9_5_5/main.rs
@@ -1,6 +1,7 @@
 use lib::path::{ExtendedPath, PathError};
 use std::path::{Path, PathBuf};
 
+// パス中のenvを展開した上でcleanする
 fn clean2(path: &Path) -> Result<PathBuf, PathError> {
     let path = path.expand_env()?;
     let path = path.clean()?;
@@ -8,10 +9,12 @@ fn clean2(path: &Path) -> Result<PathBuf, PathError> {
 }
 
 fn main() -> Result<(), PathError> {
-    let path = Path::new("${HOME}/.zshrc");
+    //存在しないパスを指定した場合、エラーを返す
+
+    let path = Path::new("${HOME}/.bashrc");
     println!("{:?}", clean2(path)?);
 
-    let path = Path::new("~/.zshrc");
+    let path = Path::new("~/.bashrc");
     println!("{:?}", clean2(path)?);
 
     Ok(())

--- a/chapter9/src/9_5_6/main.rs
+++ b/chapter9/src/9_5_6/main.rs
@@ -1,0 +1,12 @@
+use glob::{glob, Pattern, PatternError};
+use std::path::PathBuf;
+
+fn main() -> Result<(), PatternError> {
+    let pattern = Pattern::new("image-*.png")?;
+    println!("{}", pattern.matches("image-100.png"));
+
+    let paths = glob("./*.png")?;
+    let files: Vec<PathBuf> = paths.into_iter().filter_map(Result::ok).collect();
+    println!("{:?}", files);
+    Ok(())
+}

--- a/chapter9/src/9_5_7/main.rs
+++ b/chapter9/src/9_5_7/main.rs
@@ -20,6 +20,8 @@ Usage:
         .iter()
         .map(|str| OsStr::new(str))
         .collect();
+    // ディレクトリのトラバースのためにworkdir crateを利用する
+    // ディレクトリ、拡張子が合わないものについては、フィルタして除外する
     for path in WalkDir::new(root)
         .into_iter()
         .filter_map(Result::ok)

--- a/chapter9/src/9_5_7/main.rs
+++ b/chapter9/src/9_5_7/main.rs
@@ -1,0 +1,36 @@
+use lib::path::PathError;
+use std::ffi::OsStr;
+use std::{collections::HashSet, env};
+use walkdir::WalkDir;
+
+fn main() -> Result<(), PathError> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 1 {
+        println!(
+            "Find images
+
+Usage:
+    {} [path to find]",
+            &args[0]
+        );
+        std::process::exit(0);
+    }
+    let root = &args[1];
+    let image_suffix: HashSet<&OsStr> = ["jpg", "jpeg", "png", "webp", "gif", "tiff", "eps"]
+        .iter()
+        .map(|str| OsStr::new(str))
+        .collect();
+    for path in WalkDir::new(root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|f| !f.file_type().is_dir())
+        .filter(|f| {
+            let extention = f.path().extension().unwrap_or_else(|| OsStr::new(""));
+            image_suffix.contains(extention)
+        })
+    {
+        println!("{}", path.into_path().display());
+    }
+
+    Ok(())
+}

--- a/chapter9/src/9_5_7/main.rs
+++ b/chapter9/src/9_5_7/main.rs
@@ -1,5 +1,4 @@
 use lib::path::PathError;
-use std::ffi::OsStr;
 use std::{collections::HashSet, env};
 use walkdir::WalkDir;
 
@@ -16,18 +15,24 @@ Usage:
         std::process::exit(0);
     }
     let root = &args[1];
-    let image_suffix: HashSet<&OsStr> = ["jpg", "jpeg", "png", "webp", "gif", "tiff", "eps"]
+    let image_suffix: HashSet<&'static str> = ["jpg", "jpeg", "png", "webp", "gif", "tiff", "eps"]
         .iter()
-        .map(|str| OsStr::new(str))
+        .cloned()
         .collect();
-    // ディレクトリのトラバースのためにworkdir crateを利用する
+    // ディレクトリのトラバースのためにwalkdir crateを利用する
     // ディレクトリ、拡張子が合わないものについては、フィルタして除外する
+    // walkdir crateでは指定のディレクトリをスキップするような機能は存在しない
     for path in WalkDir::new(root)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|f| !f.file_type().is_dir())
         .filter(|f| {
-            let extention = f.path().extension().unwrap_or_else(|| OsStr::new(""));
+            let extention_opt = f
+                .path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.to_lowercase());
+            let extention = extention_opt.as_deref().unwrap_or("");
             image_suffix.contains(extention)
         })
     {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 
 [dependencies]
 crc32fast = "1.2.1"
+regex = "1.5"
+once_cell = "1.7.2"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,3 +2,4 @@ pub mod binary;
 pub mod env;
 pub mod image;
 pub mod io;
+pub mod path;

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -62,15 +62,11 @@ impl ExtendedPath for Path {
 
     fn expand_env(&self) -> Result<PathBuf, PathError> {
         let mut path_buf = PathBuf::new();
-        for path in self.into_iter() {
-            let path_str = path.to_str().unwrap_or("");
-            let caps_opt = RE_VAR.captures(path_str);
-            if let Some(caps) = caps_opt {
-                let expanded_var = env::var(&caps[1])?;
-                path_buf.push(expanded_var);
-                continue;
-            }
-            let caps_opt = RE_VAR_WITHOUT_BRACES.captures(path_str);
+        for path in self.iter() {
+            let path_str = path.to_string_lossy();
+            let caps_opt = RE_VAR
+                .captures(&path_str)
+                .or_else(|| RE_VAR_WITHOUT_BRACES.captures(&path_str));
             if let Some(caps) = caps_opt {
                 let expanded_var = env::var(&caps[1])?;
                 path_buf.push(expanded_var);

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -42,6 +42,22 @@ static RE_VAR_WITHOUT_BRACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"\$(.+)").u
 
 static TILDE: Lazy<&OsStr> = Lazy::new(|| OsStr::new("~"));
 
+/// extend path::Path
+/// add useful functions to path::Path
+///
+/// # Examples
+///
+/// ```
+/// use lib::path::ExtendedPath
+///
+/// let path = path::Path("./example/../example.txt");
+/// let cleaned_path = path.clean();
+/// println!("cleaned path: {}", cleaned_path);
+///
+/// let path = path::Path("~/example.txt");
+/// let expanded_path = path.expand_env();
+/// println!("expanded env path: {}", expanded_path);
+/// ```
 pub trait ExtendedPath {
     fn clean(&self) -> Result<PathBuf, PathError>;
     fn expand_env(&self) -> Result<PathBuf, PathError>;

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -1,11 +1,15 @@
-use std::env;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::path::Path;
 use std::path::PathBuf;
+use std::{env, ffi::OsStr};
 
 #[derive(Debug)]
 pub enum PathError {
     IoError(std::io::Error),
     StripPrefixError(std::path::StripPrefixError),
+    RegexError(regex::Error),
+    VarError(std::env::VarError),
 }
 
 impl From<std::io::Error> for PathError {
@@ -20,8 +24,27 @@ impl From<std::path::StripPrefixError> for PathError {
     }
 }
 
+impl From<regex::Error> for PathError {
+    fn from(error: regex::Error) -> Self {
+        PathError::RegexError(error)
+    }
+}
+
+impl From<std::env::VarError> for PathError {
+    fn from(error: std::env::VarError) -> Self {
+        PathError::VarError(error)
+    }
+}
+
+static RE_VAR: Lazy<Regex> = Lazy::new(|| Regex::new(r"\$\{(.+)\}").unwrap());
+
+static RE_VAR_WITHOUT_BRACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"\$(.+)").unwrap());
+
+static TILDE: Lazy<&OsStr> = Lazy::new(|| OsStr::new("~"));
+
 pub trait ExtendedPath {
     fn clean(&self) -> Result<PathBuf, PathError>;
+    fn expand_env(&self) -> Result<PathBuf, PathError>;
 }
 
 impl ExtendedPath for Path {
@@ -35,5 +58,32 @@ impl ExtendedPath for Path {
             .strip_prefix(current_dir)
             .map(|path| path.to_path_buf())
             .map_err(|e| e.into())
+    }
+
+    fn expand_env(&self) -> Result<PathBuf, PathError> {
+        let mut path_buf = PathBuf::new();
+        for path in self.into_iter() {
+            let path_str = path.to_str().unwrap_or("");
+            let caps_opt = RE_VAR.captures(path_str);
+            if let Some(caps) = caps_opt {
+                let expanded_var = env::var(&caps[1])?;
+                path_buf.push(expanded_var);
+                continue;
+            }
+            let caps_opt = RE_VAR_WITHOUT_BRACES.captures(path_str);
+            if let Some(caps) = caps_opt {
+                let expanded_var = env::var(&caps[1])?;
+                path_buf.push(expanded_var);
+                continue;
+            }
+            if *TILDE == path {
+                let home_dir = env::var("HOME")?;
+                path_buf.push(home_dir);
+                continue;
+            }
+
+            path_buf.push(path);
+        }
+        Ok(path_buf)
     }
 }

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -1,0 +1,39 @@
+use std::env;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum PathError {
+    IoError(std::io::Error),
+    StripPrefixError(std::path::StripPrefixError),
+}
+
+impl From<std::io::Error> for PathError {
+    fn from(error: std::io::Error) -> Self {
+        PathError::IoError(error)
+    }
+}
+
+impl From<std::path::StripPrefixError> for PathError {
+    fn from(error: std::path::StripPrefixError) -> Self {
+        PathError::StripPrefixError(error)
+    }
+}
+
+pub trait ExtendedPath {
+    fn clean(&self) -> Result<PathBuf, PathError>;
+}
+
+impl ExtendedPath for Path {
+    fn clean(&self) -> Result<PathBuf, PathError> {
+        let abs_path = self.canonicalize()?;
+        if self.is_absolute() {
+            return Ok(abs_path);
+        }
+        let current_dir = env::current_dir()?;
+        abs_path
+            .strip_prefix(current_dir)
+            .map(|path| path.to_path_buf())
+            .map_err(|e| e.into())
+    }
+}

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -48,15 +48,19 @@ static TILDE: Lazy<&OsStr> = Lazy::new(|| OsStr::new("~"));
 /// # Examples
 ///
 /// ```
-/// use lib::path::ExtendedPath
+/// use lib::path::{ExtendedPath, PathError};
+/// use std::path::Path;
 ///
-/// let path = path::Path("./example/../example.txt");
-/// let cleaned_path = path.clean();
-/// println!("cleaned path: {}", cleaned_path);
+/// fn main() -> Result<(), PathError> {
+///     let path = Path::new("./src/../Cargo.toml");
+///     let cleaned_path = path.clean()?;
+///     println!("cleaned path: {:?}", cleaned_path);
 ///
-/// let path = path::Path("~/example.txt");
-/// let expanded_path = path.expand_env();
-/// println!("expanded env path: {}", expanded_path);
+///     let path = Path::new("~/.cargo");
+///     let expanded_path = path.expand_env()?;
+///     println!("expanded env path: {:?}", expanded_path);
+///     Ok(())
+/// }
 /// ```
 pub trait ExtendedPath {
     fn clean(&self) -> Result<PathBuf, PathError>;


### PR DESCRIPTION
## 対象の Issue
#60 9.5.4 - 9.5.7

9.5.7について
- Goのfilepath.Walkの代用としてwalkdir crateを利用しています。
- 該当のディレクトリをskipするfilepath.SkipDir相当の機能がなかったため、`_build`ディレクトリをスキップする機能は省いています。

## 動作確認結果

<!-- Go 側の動作確認ができる場合はその結果と、Rust 側の動作確認の結果をお願いします。標準出力のログ等でよいです。 -->

### 9.5.4

Go
```
> go run main.go
chapter9/src/9_5_4/main.rs
/home/shnmorimoto/learning-systems-programming-in-rust/chapter9/src/9_5_4/main.rs
bin/go
```

Rust
```
> cargo run -p chapter9 --bin 9_5_4
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/9_5_4`
"chapter9/src/9_5_4/main.rs"
"/home/shnmorimoto/learning-systems-programming-in-rust/chapter9/src/9_5_4/main.rs"
"bin/go"
```

### 9.5.5

Go
```
> go run main.go
/home/shnmorimoto/.bashrc
/home/shnmorimoto/.bashrc
```

Rust
```
> cargo run -p chapter9 --bin 9_5_5
   Compiling chapter9 v0.1.0 (/home/shnmorimoto/Work/rust-sandbox/learning-systems-programming-in-rust/chapter9)
    Finished dev [unoptimized + debuginfo] target(s) in 0.70s
     Running `target/debug/9_5_5`
"/home/shnmorimoto/.bashrc"
"/home/shnmorimoto/.bashrc"
```

### 9.5.6

Go
```
> go main.go
true <nil>
[1.png 2.png]

```

Rust
```
> cargo run -p chapter9 --bin 9_5_6
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/9_5_6`
true
["1.png", "2.png"]

```

### 9.5.7

Go
```
> go run main.go ./
aaa.png
bbb/ccc/ddd.png
eee/fff.jpeg
```

Rust
```
> cargo run -p chapter9 --bin 9_5_7 ./
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/9_5_7 ./`
./aaa.png
./bbb/ccc/ddd.png
./eee/fff.jpeg

```