### PR TITLE
add 11_1 & 11_2 & 11_3 & 11_8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ version = "0.1.0"
 dependencies = [
  "lib",
  "nix 0.21.0",
+ "sysinfo",
 ]
 
 [[package]]
@@ -239,6 +240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +253,62 @@ checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "filetime"
@@ -391,6 +454,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
@@ -730,6 +799,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +917,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3899fa43ce1ab71db79fda2a3fdb119a07e25a006677d46033c9d9051c82f019"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/chapter11/Cargo.toml
+++ b/chapter11/Cargo.toml
@@ -42,3 +42,7 @@ path = "src/11_2_3/main.rs"
 [[bin]]
 name = "11_3"
 path = "src/11_3/main.rs"
+
+[[bin]]
+name = "11_8"
+path = "src/11_8/main.rs"

--- a/chapter11/Cargo.toml
+++ b/chapter11/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 lib = { path = "../lib" }
 nix = "0.21.0"
+sysinfo = "0.18.1"
 
 [[bin]]
 name = "11_1_2"
@@ -37,3 +38,7 @@ path = "src/11_2_1/main.rs"
 [[bin]]
 name = "11_2_3"
 path = "src/11_2_3/main.rs"
+
+[[bin]]
+name = "11_3"
+path = "src/11_3/main.rs"

--- a/chapter11/Cargo.toml
+++ b/chapter11/Cargo.toml
@@ -29,3 +29,11 @@ path = "src/11_1_5/main.rs"
 [[bin]]
 name = "11_1_6"
 path = "src/11_1_6/main.rs"
+
+[[bin]]
+name = "11_2_1"
+path = "src/11_2_1/main.rs"
+
+[[bin]]
+name = "11_2_3"
+path = "src/11_2_3/main.rs"

--- a/chapter11/src/11_1_3/main.rs
+++ b/chapter11/src/11_1_3/main.rs
@@ -1,3 +1,6 @@
+use nix::unistd::{getpgrp, getpid, getsid};
+
 fn main() {
-    println!("11_1_3");
+    let sid = getsid(Some(getpid())).unwrap();
+    println!("グループID: {}, セッションID: {}", getpgrp(), sid);
 }

--- a/chapter11/src/11_1_4/main.rs
+++ b/chapter11/src/11_1_4/main.rs
@@ -1,3 +1,4 @@
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 use nix::unistd::getgroups;
 use nix::unistd::{getgid, getuid};
 
@@ -6,6 +7,12 @@ fn main() {
     println!("グループID: {}", getgid());
 
     // nix クレートにおける getgroups は Apple のプラットフォームでは実行できない。
+    #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+    get_groups();
+}
+
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+fn get_groups() {
     let groups = getgroups().unwrap();
     println!("サブグループID: {:?}", groups);
 }

--- a/chapter11/src/11_1_4/main.rs
+++ b/chapter11/src/11_1_4/main.rs
@@ -1,3 +1,11 @@
+use nix::unistd::getgroups;
+use nix::unistd::{getgid, getuid};
+
 fn main() {
-    println!("11_1_4");
+    println!("ユーザーID: {}", getuid());
+    println!("グループID: {}", getgid());
+
+    // nix クレートにおける getgroups は Apple のプラットフォームでは実行できない。
+    let groups = getgroups().unwrap();
+    println!("サブグループID: {:?}", groups);
 }

--- a/chapter11/src/11_1_5/main.rs
+++ b/chapter11/src/11_1_5/main.rs
@@ -1,3 +1,8 @@
+use nix::unistd::{getegid, geteuid, getgid, getuid};
+
 fn main() {
-    println!("11_1_5");
+    println!("ユーザー ID: {}", getuid());
+    println!("グループID: {}", getgid());
+    println!("実効ユーザーID: {}", geteuid());
+    println!("実効グループID: {}", getegid());
 }

--- a/chapter11/src/11_1_6/main.rs
+++ b/chapter11/src/11_1_6/main.rs
@@ -1,3 +1,9 @@
+use nix::unistd::getcwd;
+use std::env::current_dir;
+
 fn main() {
-    println!("11_1_6");
+    // nix クレートを使用する場合は getcwd が使える。
+    println!("{}", getcwd().unwrap().to_str().unwrap());
+    // あるいは、Rust の std::env にある current_dir を使ってもよい。
+    println!("{}", current_dir().unwrap().to_str().unwrap());
 }

--- a/chapter11/src/11_2_1/main.rs
+++ b/chapter11/src/11_2_1/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let envs = std::env::vars();
+    for (key, value) in envs {
+        println!("{}={}", key, value);
+    }
+    // os.ExpandEnv 関数は Rust には存在しない。
+}

--- a/chapter11/src/11_2_3/main.rs
+++ b/chapter11/src/11_2_3/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(1);
+}

--- a/chapter11/src/11_3/main.rs
+++ b/chapter11/src/11_3/main.rs
@@ -1,0 +1,18 @@
+use nix::libc::getppid;
+// gopsutil の Rust バージョンとして rust-psutil というクレートを使用できそうだったが、
+// 実装がかなり不完全そうだった。
+// そこで、sysinfo というクレートを使っている。
+use sysinfo::{ProcessExt, System, SystemExt};
+
+fn main() {
+    // get_process に libc の pid_t を要求するので、それを取得できるように nix::libc 経由で getppid を使っている。
+    let pid = unsafe { getppid() };
+    if let Some(process) = System::new_all().get_process(pid) {
+        println!(
+            "parent pid: {}, name: {}, cmd: {:?}",
+            process.pid(),
+            process.name(),
+            process.cmd()
+        )
+    }
+}

--- a/chapter11/src/11_8/main.rs
+++ b/chapter11/src/11_8/main.rs
@@ -1,0 +1,35 @@
+use nix::sys::wait::*;
+use nix::unistd::{execve, fork, ForkResult};
+use std::env;
+use std::ffi::CString;
+
+// Go のプログラミングでは触れることのない世界として言及されているが、Rust では触れることができる。
+// 本書の中で fork(2) と execve(3) が言及されていたので、それを使用したサンプルプログラムを掲載しておく。
+fn main() {
+    // fork
+    match unsafe { fork() }.expect("fork failed") {
+        ForkResult::Parent { child } => {
+            // waitpid
+            match waitpid(child, None).expect("wait_pid failed") {
+                WaitStatus::Exited(pid, status) => {
+                    println!("exit!: pid={:?}, status={:?}", pid, status)
+                }
+                WaitStatus::Signaled(pid, status, _) => {
+                    println!("signal!: pid={:?}, status={:?}", pid, status)
+                }
+                _ => println!("abnormal exit!"),
+            }
+        }
+        ForkResult::Child => {
+            // 引数の値を取得する。
+            let args: Vec<String> = env::args().collect();
+            let dir = CString::new(args[1].to_string()).unwrap();
+            let arg = CString::new(args[2].to_string()).unwrap();
+            // env は仮で入れておく。
+            let env = CString::new("ENV=prd".to_string()).unwrap();
+
+            // execv
+            execve(&dir, &[dir.clone(), arg], &[env]).expect("execution failed.");
+        }
+    }
+}


### PR DESCRIPTION
## 対象の Issue
#89
#90 
#91 

## 動作確認結果

<!-- Go 側の動作確認ができる場合はその結果と、Rust 側の動作確認の結果をお願いします。標準出力のログ等でよいです。 -->

11.1.2

```
❯ cargo run --bin 11_1_2
プロセス ID: 99008
親プロセスID: 91603
```

11.1.3

```
❯ cargo run --bin 11_1_3
グループID: 99051, セッションID: 91603
```

11.1.4

```
❯ cargo run --bin 11_1_4
ユーザーID: 488184566
```

11.1.5

```
❯ cargo run --bin 11_1_5
ユーザー ID: 488184566
グループID: 1796141739
実効ユーザーID: 488184566
実効グループID: 1796141739
```

11.1.6

```
❯ cargo run --bin 11_1_6
/Users/xxx/github/yuk1ty/learning-systems-programming-in-rust/chapter11
/Users/xxx/github/yuk1ty/learning-systems-programming-in-rust/chapter11
```

11.2.1

```
❯ cargo run --bin 11_2_1
CARGO=/Users/xxx/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo
# ... などといった形で、OS にある環境変数が表示される。
```

11.2.3

```
❯ cargo run --bin 11_2_3
# ...何も出力しないが、プログラムは終了する。
```

11.3

```
❯ cargo run --bin 11_3
parent pid: 5987, name: zsh, cmd: ["/bin/zsh", "-l"]
```

## 備考
- 本書でもエラーハンドリングはしていなかったので、いろいろエラーハンドリングをしていません。
- 11.8 では、Rust による fork-exec のサンプルプログラムを実装して追加しておきました。